### PR TITLE
omnibusを有効化

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -78,7 +78,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   #   puppet.manifest_file  = "site.pp"
   # end
 
-  # config.omnibus.chef_version = :latest
+  config.omnibus.chef_version = :latest
 
   # Enable provisioning with chef solo, specifying a cookbooks path, roles
   # path, and data_bags path (all relative to this Vagrantfile), and adding


### PR DESCRIPTION
```
config.omnibus.chef_version = :latest
```

この設定を有効にしないとvagrant-omnibusが発動しないっぽい

[今っぽい Vagrant + Chef Solo チュートリアル - Qiita](http://qiita.com/taiki45/items/b46a2f32248720ec2bae#3-8)
